### PR TITLE
chore(device): service response recipients and minor tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,21 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@bacnet-js/client": "^2.1.4",
+        "@bacnet-js/client": "^3.0.0",
         "debug": "^4.4.1",
         "fastq": "^1.19.1"
       },
       "devDependencies": {
         "@types/debug": "^4.1.12",
-        "@types/node": "^24.0.4",
-        "typedoc": "^0.28.5",
+        "@types/node": "^24.0.13",
+        "typedoc": "^0.28.7",
         "typescript": "^5.8.3"
       }
     },
     "node_modules/@bacnet-js/client": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@bacnet-js/client/-/client-2.1.4.tgz",
-      "integrity": "sha512-vqmawTwA+nInkt9CTZ7k7D1iFw5rLokD+pBYbHSn0BTcxutEvZXPWv/+giJbpgDWfA4J6VxqZlgOJV8UdziH/A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bacnet-js/client/-/client-3.0.0.tgz",
+      "integrity": "sha512-m8Pqy4qDmGwWS+wHh3Hmv9LFSxQypU9S3dprYwNtuKSAfrV38G37eJ2K2KTtCMUk4lHS4YDBNxTSrIndNyxhmA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -34,54 +34,54 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.2.tgz",
-      "integrity": "sha512-3jXo5bNjvvimvdbIhKGfFxSnKCX+MA8wzHv55ptzk/cx8wOzT+BRcYgj8aFN3yTiTs+zvQQiaZFr7Jce1ZG3fw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.7.0.tgz",
+      "integrity": "sha512-7iY9wg4FWXmeoFJpUL2u+tsmh0d0jcEJHAIzVxl3TG4KL493JNnisdLAILZ77zcD+z3J0keEXZ+lFzUgzQzPDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.4.2",
-        "@shikijs/langs": "^3.4.2",
-        "@shikijs/themes": "^3.4.2",
-        "@shikijs/types": "^3.4.2",
+        "@shikijs/engine-oniguruma": "^3.7.0",
+        "@shikijs/langs": "^3.7.0",
+        "@shikijs/themes": "^3.7.0",
+        "@shikijs/types": "^3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.2.tgz",
-      "integrity": "sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
+      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.2.tgz",
-      "integrity": "sha512-H6azIAM+OXD98yztIfs/KH5H4PU39t+SREhmM8LaNXyUrqj2mx+zVkr8MWYqjceSjDw9I1jawm1WdFqU806rMA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
+      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.7.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.2.tgz",
-      "integrity": "sha512-qAEuAQh+brd8Jyej2UDDf+b4V2g1Rm8aBIdvt32XhDPrHvDkEnpb7Kzc9hSuHUxz0Iuflmq7elaDuQAP9bHIhg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
+      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.7.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.2.tgz",
-      "integrity": "sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
+      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -124,9 +124,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
-      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
+      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -306,17 +306,17 @@
       "license": "MIT"
     },
     "node_modules/typedoc": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.5.tgz",
-      "integrity": "sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==",
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.7.tgz",
+      "integrity": "sha512-lpz0Oxl6aidFkmS90VQDQjk/Qf2iw0IUvFqirdONBdj7jPSN9mGXhy66BcGNDxx5ZMyKKiBVAREvPEzT6Uxipw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.2.2",
+        "@gerrit0/mini-shiki": "^3.7.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "yaml": "^2.7.1"
+        "yaml": "^2.8.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   "description": "A TypeScript library for implementing BACnet IP devices in Node.js.",
   "devDependencies": {
     "@types/debug": "^4.1.12",
-    "@types/node": "^24.0.4",
-    "typedoc": "^0.28.5",
+    "@types/node": "^24.0.13",
+    "typedoc": "^0.28.7",
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@bacnet-js/client": "^2.1.4",
+    "@bacnet-js/client": "^3.0.0",
     "debug": "^4.4.1",
     "fastq": "^1.19.1"
   },

--- a/src/objects/device/types.ts
+++ b/src/objects/device/types.ts
@@ -99,7 +99,7 @@ export interface BDDeviceEvents extends BDObjectEvents {
  * This interface defines the parameters required to initialize a BACnet Device,
  * including identification, vendor information, and protocol configuration.
  */
-export type BDDeviceOpts = ClientOptions & {
+export interface BDDeviceOpts extends ClientOptions {
   
   /**
    * The device's name (Object_Name property)

--- a/src/objects/device/utils.ts
+++ b/src/objects/device/utils.ts
@@ -26,17 +26,14 @@ import {
  * @returns A promise that resolves when the notification is confirmed or rejects on error
  */
 export const sendConfirmedCovNotification = async (client: BACNetClientType, emitter: BDDevice, subscription: BDSubscription<any, any, any>, cov: BDQueuedCov<any, any, any>) => {
-  return new Promise<void>((resolve, reject) => {
-    client.confirmedCOVNotification(
-      { address: subscription.subscriber.address },
-      cov.object.identifier,
-      subscription.subscriptionProcessId,
-      emitter.identifier.instance,
-      Math.floor(Math.max(0, subscription.expiresAt - Date.now()) / 1000),
-      [{ property: { id: cov.property.identifier }, value: ensureArray(cov.value) }],
-      (err) => err ? reject(err) : resolve(),
-    );
-  });
+  await client.confirmedCOVNotification(
+    { address: subscription.subscriber.address },
+    cov.object.identifier,
+    subscription.subscriptionProcessId,
+    emitter.identifier.instance,
+    Math.floor(Math.max(0, subscription.expiresAt - Date.now()) / 1000),
+    [{ property: { id: cov.property.identifier }, value: ensureArray(cov.value) }],
+  );
 };
 
 /**


### PR DESCRIPTION
* Updates service request handlers to use the sender object from each request's headers as the recipient for service responses. Should fix issues with BBMDs and proxies. Supported by https://github.com/bacnet-js/client/pull/48.
* Updates the list of supported object types that is advertised to clients
* Updates to new major release of [@bacnet-js/client](@bacnet-js/client)